### PR TITLE
fix(NodeCard): show online days on free nodes (price === 0)

### DIFF
--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -124,16 +124,14 @@ const trafficPercentageClass = computed(() => {
 // 但在线天数、剩余天数等非金额信息仍然展示
 const showPrice = computed(() => appStore.isLoggedIn || !appStore.hidePriceWhenLoggedOut)
 
-// 左上角：在线天数（始终，只要有 created_at） + 价格（仅在 price > 0 且允许显示金额时）
+// 左上角：在线天数（由 uptime 秒数换算，始终展示） + 价格（仅在 price > 0 且允许显示金额时）
 const onlineInfoTags = computed(() => {
   const node = props.node
   const lang = appStore.lang
   const tags: string[] = []
 
-  if (node.created_at) {
-    const days = getDaysOnline(node.created_at)
-    tags.push(lang === 'zh-CN' ? `在线 ${days} 天` : `${days} days online`)
-  }
+  const days = getDaysOnline(node.uptime)
+  tags.push(lang === 'zh-CN' ? `在线 ${days} 天` : `${days} days online`)
 
   if (node.price > 0 && showPrice.value) {
     tags.push(formatPriceWithCycle(node.price, node.billing_cycle, node.currency, lang))

--- a/src/components/NodeCard.vue
+++ b/src/components/NodeCard.vue
@@ -124,16 +124,21 @@ const trafficPercentageClass = computed(() => {
 // 但在线天数、剩余天数等非金额信息仍然展示
 const showPrice = computed(() => appStore.isLoggedIn || !appStore.hidePriceWhenLoggedOut)
 
-// 左上角：在线天数（始终） + 价格（仅在允许显示金额时）
+// 左上角：在线天数（始终，只要有 created_at） + 价格（仅在 price > 0 且允许显示金额时）
 const onlineInfoTags = computed(() => {
   const node = props.node
-  if (node.price === 0)
-    return []
   const lang = appStore.lang
-  const days = getDaysOnline(node.created_at)
-  const tags = [lang === 'zh-CN' ? `在线 ${days} 天` : `${days} days online`]
-  if (showPrice.value)
+  const tags: string[] = []
+
+  if (node.created_at) {
+    const days = getDaysOnline(node.created_at)
+    tags.push(lang === 'zh-CN' ? `在线 ${days} 天` : `${days} days online`)
+  }
+
+  if (node.price > 0 && showPrice.value) {
     tags.push(formatPriceWithCycle(node.price, node.billing_cycle, node.currency, lang))
+  }
+  
   return tags
 })
 

--- a/src/utils/tagHelper.ts
+++ b/src/utils/tagHelper.ts
@@ -346,11 +346,20 @@ export function formatPriceWithCycle(
 const TRAILING_ZERO_REGEX = /\.?0+$/
 
 /**
- * 计算已在线天数（自创建时间 createdAt 起至今）
- * @param createdAt 创建时间（字符串或时间戳）
- * @returns 已在线天数，无效时间返回 0
+ * 计算已在线天数（由 uptime 秒数换算）
+ * @param uptime 在线时长（秒）
+ * @returns 已在线天数，向下取整
  */
-export function getDaysOnline(createdAt: string | number | undefined): number {
+export function getDaysOnline(uptime: number): number {
+  return Math.floor(uptime / 86400)
+}
+
+/**
+ * 计算自某个时间点起至今的天数
+ * @param createdAt 起始时间（字符串或时间戳）
+ * @returns 天数，无效时间返回 0
+ */
+export function getDaysFrom(createdAt: string | number | undefined): number {
   if (!createdAt)
     return 0
 


### PR DESCRIPTION
固定展示 ’在线xx天‘，与价格解耦，避免有价格、无价格主机同时展示时的方框大小不一致