### PR TITLE
[codex] Add managed Beijing theme mode

### DIFF
--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "Komari Glassmorphism",
   "short": "Glassmorphism",
   "description": "A Glassmorphism theme for Komari",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "sanrokamlan",
   "url": "https://github.com/sanrokamlan-prog/komari-theme-Glassmorphism",
   "preview": "preview-v2.0.0.png",
@@ -11,6 +11,7 @@
     "name": "Glassmorphism 设置",
     "data": [
       { "name": "基础设置", "type": "title" },
+      { "key": "themeMode", "name": "主题模式", "type": "select", "default": "beijing", "options": "beijing,light,dark", "help": "全站统一主题模式：beijing=按北京时间 07:00-18:59 日间、19:00-06:59 夜间；light=始终浅色；dark=始终深色。该设置由管理员统一控制，会同步到所有设备。" },
       { "key": "dataUpdateInterval", "name": "数据更新间隔", "type": "number", "default": 3, "help": "实时数据刷新间隔，单位：秒（建议 1-10 秒）" },
       { "key": "rpcTransportMode", "name": "RPC 连接模式", "type": "select", "default": "websocket", "options": "websocket,http", "help": "RPC 默认连接模式，推荐使用 websocket，若您无法使用 websocket 请选择 http" },
       { "key": "defaultViewMode", "name": "默认视图模式", "type": "select", "default": "card", "options": "card,list", "help": "节点列表的默认显示模式" },

--- a/komari-theme.json
+++ b/komari-theme.json
@@ -2,7 +2,7 @@
   "name": "Komari Glassmorphism",
   "short": "Glassmorphism",
   "description": "A Glassmorphism theme for Komari",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "sanrokamlan",
   "url": "https://github.com/sanrokamlan-prog/komari-theme-Glassmorphism",
   "preview": "preview-v2.0.0.png",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "komari-theme-Glassmorphism",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packageManager": "bun@1.3.14",
   "author": {
     "name": "Tokinx",
@@ -46,6 +46,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^24.10.13",
+    "@types/three": "^0.184.1",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/eslint-config-typescript": "^14.6.0",
     "@vue/tsconfig": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "komari-theme-Glassmorphism",
   "type": "module",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packageManager": "bun@1.3.14",
   "author": {
     "name": "Tokinx",

--- a/src/components/Background.vue
+++ b/src/components/Background.vue
@@ -8,7 +8,7 @@ const isLoaded = ref(false)
 const hasError = ref(false)
 
 const showBackground = computed(() => appStore.backgroundEnabled)
-const currentUrl = computed(() => appStore.currentBackgroundUrl)
+const currentUrl = computed(() => showBackground.value ? appStore.currentBackgroundUrl : '')
 const backgroundType = computed(() => appStore.backgroundType)
 const hasCustomBackground = computed(() => showBackground.value && !!currentUrl.value)
 const showBackgroundOverlay = computed(() => hasCustomBackground.value && appStore.backgroundOverlay > 0)
@@ -88,6 +88,19 @@ function loadImage(url: string) {
 
 const videoRef = ref<HTMLVideoElement | null>(null)
 
+function resetBackgroundState() {
+  clearImageLoader()
+
+  if (videoRef.value) {
+    videoRef.value.pause()
+    videoRef.value.removeAttribute('src')
+    videoRef.value.load()
+  }
+
+  isLoaded.value = false
+  hasError.value = false
+}
+
 function handleVideoLoaded() {
   isLoaded.value = true
   hasError.value = false
@@ -97,16 +110,16 @@ function handleVideoError() {
   hasError.value = true
 }
 
-watch([currentUrl, backgroundType], ([url, type]) => {
-  if (url && type === 'image') {
+watch([showBackground, currentUrl, backgroundType], ([enabled, url, type]) => {
+  if (!enabled || !url) {
+    resetBackgroundState()
+    return
+  }
+
+  if (type === 'image') {
     loadImage(url)
   }
-  else if (url && type === 'video') {
-    clearImageLoader()
-    isLoaded.value = false
-    hasError.value = false
-  }
-  else {
+  else if (type === 'video') {
     clearImageLoader()
     isLoaded.value = false
     hasError.value = false
@@ -114,7 +127,7 @@ watch([currentUrl, backgroundType], ([url, type]) => {
 }, { immediate: true })
 
 onUnmounted(() => {
-  clearImageLoader()
+  resetBackgroundState()
 })
 </script>
 
@@ -122,11 +135,27 @@ onUnmounted(() => {
   <div class="background-container" :style="backgroundContainerStyle">
     <Transition name="fade">
       <div v-if="showDefaultBackground" class="default-background">
-        <div class="default-background__mesh" />
-        <div class="default-background__glow default-background__glow--cyan" />
-        <div class="default-background__glow default-background__glow--violet" />
-        <div class="default-background__glow default-background__glow--mint" />
-        <div class="default-background__grid" />
+        <div class="default-background__spotlight">
+          <div class="default-background__emerald-surface">
+            <svg
+              aria-hidden="true"
+              class="default-background__pattern"
+            >
+              <defs>
+                <pattern id="glassmorphism-emerald-grid" width="72" height="56" patternUnits="userSpaceOnUse" x="-12" y="4">
+                  <path d="M.5 56V.5H72" fill="none" />
+                </pattern>
+              </defs>
+              <rect width="100%" height="100%" stroke-width="0" fill="url(#glassmorphism-emerald-grid)" />
+              <svg x="-12" y="4" class="default-background__pattern-blocks">
+                <rect stroke-width="0" width="73" height="57" x="288" y="168" />
+                <rect stroke-width="0" width="73" height="57" x="144" y="56" />
+                <rect stroke-width="0" width="73" height="57" x="504" y="168" />
+                <rect stroke-width="0" width="73" height="57" x="720" y="336" />
+              </svg>
+            </svg>
+          </div>
+        </div>
       </div>
     </Transition>
     <Transition name="fade">
@@ -174,90 +203,81 @@ onUnmounted(() => {
   position: absolute;
   inset: 0;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 12% 18%, rgb(125 211 252 / 0.32), transparent 30%),
-    radial-gradient(circle at 78% 10%, rgb(196 181 253 / 0.28), transparent 28%),
-    linear-gradient(135deg, #f8fbff 0%, #eef7ff 38%, #f6f0ff 68%, #eefdf8 100%);
+  background: rgb(248 250 252);
+  transform: scale(1.5);
+  transform-origin: top center;
 }
 
 .dark .default-background {
-  background:
-    radial-gradient(circle at 18% 16%, rgb(34 211 238 / 0.18), transparent 32%),
-    radial-gradient(circle at 82% 12%, rgb(168 85 247 / 0.2), transparent 30%),
-    linear-gradient(135deg, #08111f 0%, #101827 38%, #1a1430 68%, #061c1a 100%);
+  background: rgb(15 23 42 / 0.5);
 }
 
-.default-background__mesh,
-.default-background__grid,
-.default-background__glow {
+.default-background__spotlight,
+.default-background__emerald-surface,
+.default-background__pattern,
+.default-background__pattern-blocks {
   position: absolute;
+}
+
+.default-background__spotlight {
+  top: 0;
+  left: 50%;
+  width: 81.25rem;
+  height: 25rem;
+  margin-left: -38rem;
   pointer-events: none;
 }
 
-.default-background__mesh {
-  inset: -18%;
-  background:
-    conic-gradient(from 130deg at 28% 32%, transparent 0 20%, rgb(20 184 166 / 0.22) 32%, transparent 45% 100%),
-    conic-gradient(from 320deg at 74% 62%, transparent 0 18%, rgb(59 130 246 / 0.18) 30%, transparent 48% 100%),
-    linear-gradient(115deg, transparent 0 40%, rgb(255 255 255 / 0.58) 48%, transparent 58% 100%);
-  filter: blur(28px);
-  transform: rotate(-8deg);
+.dark .default-background__spotlight {
+  -webkit-mask-image: linear-gradient(white, transparent);
+  mask-image: linear-gradient(white, transparent);
 }
 
-.dark .default-background__mesh {
-  background:
-    conic-gradient(from 130deg at 28% 32%, transparent 0 20%, rgb(45 212 191 / 0.16) 32%, transparent 45% 100%),
-    conic-gradient(from 320deg at 74% 62%, transparent 0 18%, rgb(96 165 250 / 0.14) 30%, transparent 48% 100%),
-    linear-gradient(115deg, transparent 0 40%, rgb(255 255 255 / 0.08) 48%, transparent 58% 100%);
-}
-
-.default-background__glow {
-  border-radius: 9999px;
-  filter: blur(10px);
-  opacity: 0.7;
-}
-
-.default-background__glow--cyan {
-  top: 10%;
-  left: 4%;
-  width: 38rem;
-  height: 38rem;
-  background: rgb(56 189 248 / 0.22);
-}
-
-.default-background__glow--violet {
-  right: -8%;
-  top: -10%;
-  width: 34rem;
-  height: 34rem;
-  background: rgb(167 139 250 / 0.24);
-}
-
-.default-background__glow--mint {
-  right: 16%;
-  bottom: -18%;
-  width: 46rem;
-  height: 46rem;
-  background: rgb(52 211 153 / 0.16);
-}
-
-.dark .default-background__glow {
-  opacity: 0.55;
-}
-
-.default-background__grid {
+.default-background__emerald-surface {
   inset: 0;
-  background-image:
-    linear-gradient(rgb(15 23 42 / 0.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(15 23 42 / 0.055) 1px, transparent 1px);
-  background-size: 46px 46px;
-  mask-image: radial-gradient(circle at 50% 28%, black, transparent 72%);
+  overflow: hidden;
+  background: linear-gradient(90deg, rgb(16 185 129 / 0.4), rgb(190 242 100 / 0.4));
+  opacity: 0.4;
+  -webkit-mask-image: radial-gradient(farthest-side at top, white, transparent);
+  mask-image: radial-gradient(farthest-side at top, white, transparent);
 }
 
-.dark .default-background__grid {
-  background-image:
-    linear-gradient(rgb(255 255 255 / 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(255 255 255 / 0.06) 1px, transparent 1px);
+.dark .default-background__emerald-surface {
+  background: linear-gradient(90deg, rgb(16 185 129 / 0.3), rgb(190 242 100 / 0.3));
+  opacity: 1;
+}
+
+.default-background__pattern {
+  inset-inline: 0;
+  top: -50%;
+  width: 100%;
+  height: 200%;
+  fill: rgb(0 0 0 / 0.4);
+  stroke: rgb(0 0 0 / 0.5);
+  mix-blend-mode: overlay;
+  transform: skewY(-18deg);
+}
+
+.dark .default-background__pattern {
+  fill: rgb(255 255 255 / 0.025);
+  stroke: rgb(255 255 255 / 0.05);
+}
+
+.default-background__pattern-blocks {
+  overflow: visible;
+}
+
+@media (max-width: 768px) {
+  .default-background {
+    transform: scale(1.25);
+  }
+
+  .default-background__spotlight {
+    left: 50%;
+    width: 60rem;
+    height: 22rem;
+    margin-left: -30rem;
+  }
 }
 
 .background-loading {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -16,10 +16,22 @@ const isScrolled = inject<ReturnType<typeof ref<boolean>>>('isScrolled', ref(fal
 const siteFavicon = ref('/favicon.ico')
 
 const actionButtons = computed(() => {
-  const buttons = [
+  const themeTitleMap = {
+    beijing: appStore.isBeijingDaytime ? '北京时间自动：日间模式' : '北京时间自动：夜间模式',
+    light: '后台指定：浅色主题',
+    dark: '后台指定：深色主题',
+  } as const
+
+  const themeIconMap = {
+    beijing: appStore.isBeijingDaytime ? 'icon-park-outline:sun-one' : 'icon-park-outline:moon',
+    light: 'icon-park-outline:sun-one',
+    dark: 'icon-park-outline:moon',
+  } as const
+
+  const buttons: Array<{ title: string, icon: string, action: string }> = [
     {
-      title: appStore.themeMode === 'auto' ? '自动主题' : appStore.themeMode === 'light' ? '浅色主题' : '深色主题',
-      icon: appStore.themeMode === 'auto' ? 'icon-park-outline:dark-mode' : appStore.themeMode === 'light' ? 'icon-park-outline:sun-one' : 'icon-park-outline:moon',
+      title: `${themeTitleMap[appStore.managedThemeMode]}（后台统一控制）`,
+      icon: themeIconMap[appStore.managedThemeMode],
       action: 'toggleTheme',
     },
   ]
@@ -37,7 +49,7 @@ const actionButtons = computed(() => {
 function handleButtonClick(action: string) {
   switch (action) {
     case 'toggleTheme':
-      appStore.updateThemeMode()
+      window.$message?.info?.('主题模式由后台 Glassmorphism 设置统一控制')
       break
     case 'jumpToSetting':
       location.href = '/admin'

--- a/src/components/Provider.vue
+++ b/src/components/Provider.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { ThemeMode } from '@/stores/app'
-import { useDark } from '@vueuse/core'
-import { computed, provide, ref, watch } from 'vue'
+import { provide, ref, watch } from 'vue'
 import { BackTop } from '@/components/ui/back-top'
 import { useAppStore } from '@/stores/app'
 
@@ -9,21 +7,6 @@ const appStore = useAppStore()
 
 const isScrolled = ref(false)
 provide('isScrolled', isScrolled)
-
-const themeMode = computed<ThemeMode>({
-  get: () => appStore.themeMode,
-  set: mode => appStore.updateThemeMode(mode),
-})
-
-useDark({
-  storageKey: null,
-  storageRef: themeMode,
-  selector: 'html',
-  attribute: 'class',
-  valueDark: 'dark',
-  valueLight: '',
-  initialValue: 'auto',
-})
 
 watch(
   () => appStore.isDark,

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,10 +1,11 @@
 import type { PublicSettings } from '@/utils/api'
 import type { ByteDecimalsConfig } from '@/utils/helper'
-import { usePreferredDark, useStorageAsync } from '@vueuse/core'
+import { useStorageAsync } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 
 export type ThemeMode = 'auto' | 'light' | 'dark'
+export type ManagedThemeMode = 'beijing' | 'light' | 'dark'
 export type GeneralCardKey
   = | 'memory'
     | 'disk'
@@ -240,6 +241,24 @@ function isValidThemeMode(value: unknown): value is ThemeMode {
   return value === 'auto' || value === 'light' || value === 'dark'
 }
 
+function isValidManagedThemeMode(value: unknown): value is ManagedThemeMode {
+  return value === 'beijing' || value === 'light' || value === 'dark'
+}
+
+function getBeijingHour(timestamp: number): number {
+  const hour = new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit',
+    hour12: false,
+    timeZone: 'Asia/Shanghai',
+  }).format(new Date(timestamp))
+
+  const parsed = Number.parseInt(hour, 10)
+  if (!Number.isFinite(parsed))
+    return new Date(timestamp).getHours()
+
+  return parsed === 24 ? 0 : parsed
+}
+
 function isGeneralCardKey(value: string): value is GeneralCardKey {
   return (ALL_GENERAL_CARD_KEYS as readonly string[]).includes(value)
 }
@@ -330,6 +349,13 @@ const useAppStore = defineStore('app', () => {
 
   // 使用 null 表示未设置，等待主题配置加载后决定
   const storedViewMode = useStorageAsync<NodeViewMode | null>('nodeViewMode', null, localStorage)
+
+  const beijingTimeTick = ref(Date.now())
+  if (typeof window !== 'undefined') {
+    window.setInterval(() => {
+      beijingTimeTick.value = Date.now()
+    }, 60 * 1000)
+  }
 
   // 计算属性：从主题配置获取默认视图模式
   const defaultViewMode = computed<NodeViewMode>(() => {
@@ -544,21 +570,28 @@ const useAppStore = defineStore('app', () => {
     }
   }, { immediate: true })
 
-  // 使用 VueUse 的 usePreferredDark 检测系统主题偏好
-  const prefersDark = usePreferredDark()
-
   watch(themeMode, (mode) => {
     if (!isValidThemeMode(mode)) {
       themeMode.value = 'auto'
     }
   }, { immediate: true })
 
+  const managedThemeMode = computed<ManagedThemeMode>(() => {
+    const value = themeSettings.value.themeMode
+    return isValidManagedThemeMode(value) ? value : 'beijing'
+  })
+
+  const isBeijingDaytime = computed<boolean>(() => {
+    const hour = getBeijingHour(beijingTimeTick.value)
+    return hour >= 7 && hour < 19
+  })
+
   // 计算当前是否为暗色模式
   const isDark = computed(() => {
-    if (themeMode.value === 'auto') {
-      return prefersDark.value
-    }
-    return themeMode.value === 'dark'
+    if (managedThemeMode.value === 'beijing')
+      return !isBeijingDaytime.value
+
+    return managedThemeMode.value === 'dark'
   })
 
   const resolvedThemeMode = computed<'light' | 'dark'>(() => isDark.value ? 'dark' : 'light')
@@ -572,19 +605,8 @@ const useAppStore = defineStore('app', () => {
   })
 
   function updateThemeMode(mode?: ThemeMode) {
-    if (mode) {
-      themeMode.value = isValidThemeMode(mode) ? mode : 'auto'
-      return
-    }
-
-    const nextMode: Record<ThemeMode, ThemeMode> = {
-      auto: 'light',
-      light: 'dark',
-      dark: 'auto',
-    }
-
-    const currentMode = isValidThemeMode(themeMode.value) ? themeMode.value : 'auto'
-    themeMode.value = nextMode[currentMode]
+    // 主题模式由 Komari 后台的主题配置统一控制，避免不同设备使用本地偏好导致显示不一致。
+    void mode
   }
 
   function updateLoginState(loggedIn: boolean) {
@@ -594,6 +616,8 @@ const useAppStore = defineStore('app', () => {
   return {
     loading,
     themeMode,
+    managedThemeMode,
+    isBeijingDaytime,
     isDark,
     resolvedThemeMode,
     lang,


### PR DESCRIPTION
## Summary

- add a managed `themeMode` setting for the Komari theme configuration
- support a Beijing-time automatic mode: light from 07:00-18:59, dark from 19:00-06:59
- keep light/dark as admin-forced modes and remove per-device local theme switching
- show the current managed mode in the header tooltip instead of changing local storage
- add `@types/three` so the current v2 map renderer type-checks successfully

## Validation

- `npx bun@1.3.14 run build`

## Notes

The new default is `beijing`, so all visitors/devices follow the admin-managed theme setting from Komari instead of each browser's local preference.