### PR TITLE
fix(metrics): preserve cumulative traffic counter semantics

### DIFF
--- a/src/components/LoadChart.vue
+++ b/src/components/LoadChart.vue
@@ -558,6 +558,10 @@ async function loadMetricHistoryRecords(params: Pick<MetricQueryParams, 'hours' 
     fill_empty: true,
     max_points: METRIC_HISTORY_MAX_POINTS,
     aggregation: 'avg',
+    aggregation_by_metric: {
+      'net.total.up': 'last',
+      'net.total.down': 'last',
+    },
   })
 
   const series = normalizeMetricSeriesList(result.series)

--- a/tests/visual/visual.spec.ts
+++ b/tests/visual/visual.spec.ts
@@ -176,6 +176,35 @@ test('detail short history falls back when metric history omits CPU', async ({ p
   }
 })
 
+test('detail history keeps cumulative traffic counters on their last value', async ({ page }) => {
+  const historyCalls: Array<Record<string, unknown>> = []
+
+  page.on('request', (request) => {
+    if (!request.url().endsWith('/api/rpc2'))
+      return
+
+    const payload = request.postDataJSON() as { method?: string, params?: Record<string, unknown> } | null
+    const metricKeys = Array.isArray(payload?.params?.metric_keys) ? payload.params.metric_keys : []
+    if (payload?.method === 'public:queryMetrics' && metricKeys.includes('net.total.up'))
+      historyCalls.push(payload.params ?? {})
+  })
+
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await installKomariFixture(page)
+  await openStablePage(page, '/instance/00000000-0000-4000-8000-000000000001')
+
+  await page.locator('[data-load-chart-range]').getByRole('tab', { name: '1 天', exact: true }).click()
+  await expect.poll(() => historyCalls.length).toBeGreaterThan(0)
+
+  expect(historyCalls.at(-1)).toMatchObject({
+    aggregation: 'avg',
+    aggregation_by_metric: {
+      'net.total.up': 'last',
+      'net.total.down': 'last',
+    },
+  })
+})
+
 test('detail ping requests stay scoped to the current node', async ({ page }) => {
   const currentUuid = '00000000-0000-4000-8000-000000000001'
   const metricCalls: Array<{ method: string, params: Record<string, unknown> }> = []


### PR DESCRIPTION
## Summary

- keep `avg` as the default aggregation for ordinary gauge metrics
- aggregate cumulative `net.total.up` / `net.total.down` counters with `last`
- add a browser-level RPC request contract regression test

## Scope

This change only affects the historical metric query in `LoadChart.vue`. It does not change live node counters, traffic quotas, quota modes, cards, agents, or Komari backend accounting.

There is deliberately no per-metric override for `traffic.up` / `traffic.down` in this PR.

## Rationale

`net.total.*` values are cumulative counters. When Komari downsamples a historical window, the last sample in each bucket preserves the counter state at that bucket boundary; averaging cumulative samples blurs that boundary value.

Komari's public metric API supports `aggregation_by_metric`, so the fix remains at the query boundary without frontend-side data correction.

## Validation

- `npm run type-check`
- `npm run build-only`
- `npx eslint src/components/LoadChart.vue tests/visual/visual.spec.ts`
- `npx playwright test tests/visual/visual.spec.ts --grep "cumulative traffic counters"`
- `git diff --check`
